### PR TITLE
SVG now doubles as save-file; existing nodes can now be edited

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -129,3 +129,7 @@ label {
 	background-color: #fff;
 	box-shadow: 0 1px 3px rgba(0,0,0,0.1), 0 1px 2px rgba(0,0,0,0.2);
 }
+
+.help-window li {
+	padding: 5px;
+}

--- a/css/index.css
+++ b/css/index.css
@@ -106,3 +106,13 @@ pre {
 label {
 	padding: 10px;
 }
+
+.help-window {
+	position: absolute;
+	top: 150px;
+	left: 250px;
+	width: 400px;
+	padding: 10px 10px 10px 20px;
+	background-color: #fff;
+	box-shadow: 0 1px 3px rgba(0,0,0,0.1), 0 1px 2px rgba(0,0,0,0.2);
+}

--- a/css/index.css
+++ b/css/index.css
@@ -91,13 +91,26 @@ section {
 
 .code-output {
 	position: absolute;
-	top: 600px;
+	top: 620px;
 	width: 800px;
 	padding: 10px;
 }
 
+@keyframes flash {
+	from {opacity: 0;}
+	to {opacity: 1;}
+}
+
+.code-output code.copied {
+	animation-name: flash;
+	animation-duration: 200ms;
+}
+
+.code-output button.copy {
+	float: right;
+}
+
 pre {
-	padding: 10px;
 	overflow-x: auto;
 	white-space: pre-wrap;
 	word-wrap: break-spaces;

--- a/css/index.css
+++ b/css/index.css
@@ -71,11 +71,11 @@ section {
 	border-bottom: 1px solid #ddd;
 }
 
-.tensor-creator .svg-container {
+.tensor-editor .svg-container {
 	height: 200px;
 }
 
-.tensor-creator .workspace {
+.tensor-editor .workspace {
     background-color: #f9f9f9;
 }
 

--- a/css/index.css
+++ b/css/index.css
@@ -106,7 +106,7 @@ section {
 	animation-duration: 200ms;
 }
 
-.code-output button.copy {
+.code-output #copy-button {
 	float: right;
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -129,6 +129,9 @@ let app = new Vue({
                     this.undo();
                 }
             }
+            else if (char === 'H') {
+                this.help = !this.help;
+            }
             else if (char === 'C') {
                 document.getElementById('copy-button').click();
             }
@@ -232,6 +235,7 @@ Vue.component(
                     <li><strong>Shift+Ctrl+O</strong> / <strong>⇧⌘O</strong> - open new workspace</li>
                     <li><strong>Ctrl+Z</strong> / <strong>⌘Z</strong> - undo</li>
                     <li><strong>Shift+Ctrl+Z</strong> / <strong>⇧⌘Z</strong> - redo</li>
+                    <li><strong>Ctrl+H</strong> / <strong>⌘H</strong> - show this help</li>
                     <li><strong>Ctrl+C</strong> / <strong>⌘C</strong> - copy code output to clipboard</li>
                     <li><strong>Ctrl+A</strong> / <strong>⌘A</strong> - select all nodes</li>
                     <li><strong>Ctrl+D</strong> / <strong>⌘D</strong> - deselect nodes</li>

--- a/js/app.js
+++ b/js/app.js
@@ -89,6 +89,9 @@ let app = new Vue({
     watch: {
         state: {
             handler: function() {
+                if (this.state.draggingNode) {
+                    return;
+                }
                 window.localStorage.setItem("state", JSON.stringify(this.state));
             },
             deep: true

--- a/js/app.js
+++ b/js/app.js
@@ -80,6 +80,11 @@ let app = new Vue({
             catch (e) {
             }
         }
+        else {
+            // First-time user; load example state
+            this.state.nodes = JSON.parse(JSON.stringify(exampleState.nodes));
+            this.state.edges = JSON.parse(JSON.stringify(exampleState.edges));
+        }
     },
     watch: {
         state: {

--- a/js/app.js
+++ b/js/app.js
@@ -101,47 +101,51 @@ let app = new Vue({
         closeHelp: function() {
             this.help = false;
         },
-        keyPressed: function(event) {
+        keyDown: function(event) {
+            if (event.key === 'Backspace') {
+                this.deleteSelectedNodes();
+            }
+            if (!event.metaKey && !event.ctrlKey) {
+                return;
+            }
             let char;
-            if (event.which == null) {
-                char = String.fromCharCode(event.keyCode);
-            }
-            else if (event.which !== 0 && event.charCode !== 0) {
-                char = String.fromCharCode(event.which);
-            }
-            if (char === 'n') {
-                this.newWorkspace();
-            }
-            else if (char === 'e') {
+            char = String.fromCharCode(event.which);
+            if (char === 'S') {
                 this.exportSVG();
             }
-            else if (char === 'o') {
-                document.getElementById('load-file').click();
+            else if (char === 'O') {
+                if (event.shiftKey) {
+                    this.newWorkspace();
+                }
+                else {
+                    document.getElementById('load-file').click();
+                }
             }
-            else if (char === 'z') {
-                this.undo();
+            else if (char === 'Z') {
+                if (event.shiftKey) {
+                    this.redo();
+                }
+                else {
+                    this.undo();
+                }
             }
-            else if (char === 'r') {
-                this.redo();
-            }
-            else if (char === 'c') {
+            else if (char === 'C') {
                 document.getElementById('copy-button').click();
             }
-            else if (char === 'a') {
+            else if (char === 'A') {
                 let allNodes = [];
                 this.state.nodes.forEach(function(node) {
                     allNodes.push(node);
                 });
                 this.state.selectedNodes = allNodes;
             }
-            else if (char === 'd') {
+            else if (char === 'D') {
                 this.state.selectedNodes = [];
             }
-        },
-        keyDown: function(event) {
-            if (event.key === 'Backspace') {
-                this.deleteSelectedNodes();
+            else {
+                return;
             }
+            event.preventDefault(); event.stopPropagation();
         }
     },
     mounted: function() {
@@ -158,7 +162,6 @@ let app = new Vue({
             this.state.nodes = JSON.parse(JSON.stringify(exampleState.nodes));
             this.state.edges = JSON.parse(JSON.stringify(exampleState.edges));
         }
-        document.addEventListener('keypress', this.keyPressed);
         document.addEventListener('keydown', this.keyDown);
     },
     watch: {
@@ -224,15 +227,15 @@ Vue.component(
                 <h2>Help</h2>
                 <h3>Hotkeys</h3>
                 <ul>
-                    <li><strong>N</strong> - new workspace</li>
-                    <li><strong>E</strong> - export SVG</li>
-                    <li><strong>O</strong> - open SVG</li>
-                    <li><strong>Z</strong> - undo</li>
-                    <li><strong>R</strong> - redo</li>
-                    <li><strong>C</strong> - copy code output to clipboard</li>
-                    <li><strong>A</strong> - select all nodes</li>
-                    <li><strong>D</strong> - deselect nodes</li>
-                    <li><strong>Backspace</strong> - delete selected nodes</li>
+                    <li><strong>Ctrl+S</strong> / <strong>⌘S</strong> - export SVG</li>
+                    <li><strong>Ctrl+O</strong> / <strong>⌘O</strong> - open workspace from SVG</li>
+                    <li><strong>Shift+Ctrl+O</strong> / <strong>⇧⌘O</strong> - open new workspace</li>
+                    <li><strong>Ctrl+Z</strong> / <strong>⌘Z</strong> - undo</li>
+                    <li><strong>Shift+Ctrl+Z</strong> / <strong>⇧⌘Z</strong> - redo</li>
+                    <li><strong>Ctrl+C</strong> / <strong>⌘C</strong> - copy code output to clipboard</li>
+                    <li><strong>Ctrl+A</strong> / <strong>⌘A</strong> - select all nodes</li>
+                    <li><strong>Ctrl+D</strong> / <strong>⌘D</strong> - deselect nodes</li>
+                    <li><strong>Backspace</strong> / <strong>⌫</strong> - delete selected nodes</li>
                 </ul>
             </div>
         `

--- a/js/app.js
+++ b/js/app.js
@@ -124,6 +124,9 @@ let app = new Vue({
             else if (char === 'r') {
                 this.redo();
             }
+            else if (char === 'c') {
+                document.getElementById('copy-button').click();
+            }
             else if (char === 'a') {
                 let allNodes = [];
                 this.state.nodes.forEach(function(node) {
@@ -226,6 +229,7 @@ Vue.component(
                     <li><strong>O</strong> - open SVG</li>
                     <li><strong>Z</strong> - undo</li>
                     <li><strong>R</strong> - redo</li>
+                    <li><strong>C</strong> - copy code output to clipboard</li>
                     <li><strong>A</strong> - select all nodes</li>
                     <li><strong>D</strong> - deselect nodes</li>
                     <li><strong>Backspace</strong> - delete selected nodes</li>

--- a/js/app.js
+++ b/js/app.js
@@ -20,7 +20,8 @@ let app = new Vue({
         pastStates: [], // used for undo
         futureStates: [], // used for redo
         undoing: false,
-        redoing: false
+        redoing: false,
+        help: false
     },
     methods: {
         newWorkspace: function(event) {
@@ -92,6 +93,13 @@ let app = new Vue({
                 this.redoing = true;
                 this.state = JSON.parse(this.futureStates.pop());
             }
+        },
+        openHelp: function(event) {
+            event.preventDefault();
+            this.help = true;
+        },
+        closeHelp: function() {
+            this.help = false;
         },
         keyPressed: function(event) {
             let char;
@@ -185,10 +193,44 @@ let app = new Vue({
                 <input type="file" id="load-file" accept="image/svg+xml" @change="loadFile($event.target.files)">
                 <button @click="undo" :disabled="pastStates.length <= 1">Undo</button>
                 <button @click="redo" :disabled="futureStates.length === 0">Redo</button>
+                <a href="" class="export" @click="openHelp">Help</a>
             </div>
 			<toolbar :state="state" />
             <code-output :state="state" />
+            <help-window :open="help" @close="closeHelp()" />
         </div>
 
     `
 });
+
+Vue.component(
+    'help-window',
+    {
+        props: {
+            open: Boolean
+        },
+        methods: {
+            close: function(event) {
+                event.preventDefault();
+                this.$emit('close');
+            }
+        },
+        template: `
+            <div class="help-window" v-if="open">
+                <a class="delete" href="" @click="close">close</a>
+                <h2>Help</h2>
+                <h3>Hotkeys</h3>
+                <ul>
+                    <li><strong>N</strong> - new workspace</li>
+                    <li><strong>E</strong> - export SVG</li>
+                    <li><strong>O</strong> - open SVG</li>
+                    <li><strong>Z</strong> - undo</li>
+                    <li><strong>R</strong> - redo</li>
+                    <li><strong>A</strong> - select all nodes</li>
+                    <li><strong>D</strong> - deselect nodes</li>
+                    <li><strong>Backspace</strong> - delete selected nodes</li>
+                </ul>
+            </div>
+        `
+    }
+);

--- a/js/edge.js
+++ b/js/edge.js
@@ -20,6 +20,11 @@ Vue.component(
             edge: Array,
             state: Object
         },
+        data: function() {
+            return {
+                highlighted: false
+            }
+        },
         methods: {
             deleteEdge: function() {
                 console.log('delete');
@@ -29,6 +34,15 @@ Vue.component(
                     //     || edge[1][0] !== this.edge[1][0] || edge[1][1] !== this.edge[1][1];
                     return edge !== t.edge;
                 });
+            },
+            onMouseEnter: function() {
+                if (this.state.draggingNode || this.state.draggingProtoEdge) {
+                    return;
+                }
+                this.highlighted = true;
+            },
+            onMouseLeave: function() {
+                this.highlighted = false;
             }
         },
         computed: {
@@ -55,12 +69,15 @@ Vue.component(
             },
             y2: function() {
                 return this.node2.position.y + this.getAxisPoints(this.node2.axes[this.edge[1][1]].position, this.angle2, this.node2.rotation).y2;
-            }
+            },
+            stroke: function() {
+                return this.highlighted ? '#bbb' : '#ddd';
+            },
         },
         template: `
-            <g @click="deleteEdge">
+            <g @click="deleteEdge" @mouseenter="onMouseEnter" @mouseleave="onMouseLeave">
                 <line class="edge" :x1="x1" :y1="y1" :x2="x2" :y2="y2"
-                    stroke="#ddd" stroke-width="5" stroke-linecap="round" />
+                    :stroke="stroke" stroke-width="5" stroke-linecap="round" />
                 <text v-if="edge[2]" :x="0.5 * (x1 + x2)" :y="0.5 * (y1 + y2)"
                     style="font: normal 15px sans-serif; text-anchor: middle; dominant-baseline: middle;">
                     {{edge[2]}}

--- a/js/edge.js
+++ b/js/edge.js
@@ -20,6 +20,17 @@ Vue.component(
             edge: Array,
             state: Object
         },
+        methods: {
+            deleteEdge: function() {
+                console.log('delete');
+                let t = this;
+                this.state.edges = this.state.edges.filter(function(edge) {
+                    // return edge[0][0] !== this.edge[0][0] || edge[0][1] !== this.edge[0][1]
+                    //     || edge[1][0] !== this.edge[1][0] || edge[1][1] !== this.edge[1][1];
+                    return edge !== t.edge;
+                });
+            }
+        },
         computed: {
             node1: function() {
                 return this.getNode(this.edge[0][0]);
@@ -47,7 +58,7 @@ Vue.component(
             }
         },
         template: `
-            <g>
+            <g @click="deleteEdge">
                 <line class="edge" :x1="x1" :y1="y1" :x2="x2" :y2="y2"
                     stroke="#ddd" stroke-width="5" stroke-linecap="round" />
                 <text v-if="edge[2]" :x="0.5 * (x1 + x2)" :y="0.5 * (y1 + y2)"

--- a/js/initialState.js
+++ b/js/initialState.js
@@ -17,7 +17,12 @@ let initialState = {
     renderLaTeX: true,
     selectedNodes: [],
     draggingNode: false,
-    nodes: [
+    nodes: [],
+    edges: []
+};
+
+let exampleState = {
+        nodes: [
         {
             name: 't1',
             displayName: 't_1',
@@ -27,7 +32,7 @@ let initialState = {
                 {name: null, angle: Math.PI / 2, position: [0, 0]},
                 {name: null, angle: Math.PI, position: [0, 0]},
             ],
-			position: {x: 200, y: 300},
+            position: {x: 200, y: 300},
             rotation: 0,
             hue: 175.5
         },

--- a/js/initialState.js
+++ b/js/initialState.js
@@ -17,6 +17,7 @@ let initialState = {
     renderLaTeX: true,
     selectedNodes: [],
     draggingNode: false,
+    draggingProtoEdge: false,
     nodes: [],
     edges: []
 };

--- a/js/mixins.js
+++ b/js/mixins.js
@@ -52,6 +52,23 @@ let mixinGet = {
 	}
 };
 
+let mixinDelete = {
+	methods: {
+		deleteSelectedNodes: function() {
+			let t = this;
+			this.state.selectedNodes.forEach(function(selectedNode) {
+				t.state.edges = t.state.edges.filter(function(edge) {
+					return edge[0][0] !== selectedNode.name && edge[1][0] !== selectedNode.name
+				});
+				t.state.nodes = t.state.nodes.filter(function(node) {
+					return node.name !== selectedNode.name;
+				});
+			});
+			this.state.selectedNodes = [];
+		}
+	}
+};
+
 let mixinGeometry = {
 	data: function() {
 		return {

--- a/js/output.js
+++ b/js/output.js
@@ -20,7 +20,8 @@ Vue.component(
         },
         data: function() {
             return {
-                ncon: true  // Use ncon() in output code.
+                ncon: true, // Use ncon() in output code.
+                copied: false
             }
         },
         created: function() {
@@ -124,15 +125,31 @@ Vue.component(
             edgeName: function(edge) {
                 let name = edge[2];
                 return name ? `, name="${name}"` : ``;
+            },
+            copy: function() {
+                let codeText = document.createElement('textarea');
+                codeText.value = this.outputCode;
+                document.body.appendChild(codeText);
+                codeText.select();
+                document.execCommand('copy');
+                document.body.removeChild(codeText);
+                this.copied = true;
+                let t = this;
+                setTimeout(function() {
+                    t.copied = false;
+                }, 200);
             }
         },
 		template: `
 			<div class="code-output">
-			    <span class="checkbox-holder">
-                    <input type="checkbox" id="checkbox-ncon" v-model="ncon">
-                    <label for="checkbox-ncon">Use <code>ncon()</code></label>
+			    <span>
+                    <span class="checkbox-holder">
+                        <input type="checkbox" id="checkbox-ncon" v-model="ncon">
+                        <label for="checkbox-ncon">Use <code>ncon()</code></label>
+                    </span>
+                    <button class="copy" @click="copy">Copy to clipboard</button>
                 </span>
-                <pre><code class="hljs" v-html="highlightedCode"></code></pre>
+                <pre><code class="hljs" :class="{'copied': copied}" v-html="highlightedCode"></code></pre>
 			</div>
 		`
 	}

--- a/js/output.js
+++ b/js/output.js
@@ -147,7 +147,7 @@ Vue.component(
                         <input type="checkbox" id="checkbox-ncon" v-model="ncon">
                         <label for="checkbox-ncon">Use <code>ncon()</code></label>
                     </span>
-                    <button class="copy" @click="copy">Copy to clipboard</button>
+                    <button id="copy-button" @click="copy">Copy to clipboard</button>
                 </span>
                 <pre><code class="hljs" :class="{'copied': copied}" v-html="highlightedCode"></code></pre>
 			</div>

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -216,6 +216,7 @@ Vue.component(
                     if (edge[1][0] === node.name || edge[1][0] === originalName) {
                         return edge[1][1] < node.axes.length
                     }
+                    return true;
                 });
                 // Rename edges if there is a name change
                 if (originalName) {

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -25,6 +25,9 @@ Vue.component(
             }
         },
         methods: {
+            stopPropagation: function(event) {
+                event.stopPropagation();
+            },
             deselectNode: function() {
                 this.state.selectedNodes = [];
             },
@@ -77,7 +80,8 @@ Vue.component(
                         </div>
                         <h4>Copy Node</h4>
                         <form @submit="copyNode">
-                            <input type="text" v-model="copyNodeName" placeholder="name of copy" />
+                            <input type="text" v-model="copyNodeName" @keypress="stopPropagation" @keydown="stopPropagation"
+                                placeholder="name of copy" />
                             <input type="submit" value="Copy" :disabled="copyNodeDisabled" />
                         </form>
                     </section>
@@ -97,7 +101,7 @@ Vue.component(
 Vue.component(
     'tensor-editor',
     {
-        mixins: [mixinGeometry],
+        mixins: [mixinGeometry, mixinDelete],
         props: {
             state: Object
         },
@@ -151,6 +155,9 @@ Vue.component(
             }
         },
         methods: {
+            stopPropagation: function(event) {
+                event.stopPropagation();
+            },
             reset: function() {
                 this.node = JSON.parse(JSON.stringify(this.nodeInitial));
             },
@@ -198,15 +205,7 @@ Vue.component(
             },
             deleteNode: function(event) {
                 event.preventDefault();
-                let selectedName = this.state.selectedNodes[0].name;
-
-                this.state.edges = this.state.edges.filter(function(edge) {
-                    return edge[0][0] !== selectedName && edge[1][0] !== selectedName
-                });
-                this.state.nodes = this.state.nodes.filter(function(node) {
-                    return node.name !== selectedName;
-                });
-                this.state.selectedNodes = [];
+                this.deleteSelectedNodes();
             },
             pushNode: function(node, originalName) {
                 // Eliminate edges that no longer connect to axes
@@ -439,8 +438,9 @@ Vue.component(
                 <div class="button-holder">
                     <h4>Name</h4>
                     <form @submit="updateNode">
-                        <input type="text" v-model="node.name" placeholder="node name" />
-                        <input type="text" v-if="renderLaTeX" v-model="node.displayName" placeholder="LaTeX label" />
+                        <input type="text" v-model="node.name" @keypress="stopPropagation" @keydown="stopPropagation" placeholder="node name" />
+                        <input type="text" v-if="renderLaTeX" v-model="node.displayName" @keypress="stopPropagation" @keydown="stopPropagation" 
+                            placeholder="LaTeX label" />
                         <input type="submit" :value="createMode ? 'Create' : 'Edit'" :disabled="createNodeDisabled" />
                     </form>
                 </div>
@@ -457,6 +457,9 @@ Vue.component(
             state: Object
         },
         methods: {
+            stopPropagation: function(event) {
+                event.stopPropagation();
+            },
             deleteEdge: function(event, edge) {
                 event.preventDefault();
                 this.state.edges = this.state.edges.filter(function(candidate) {
@@ -479,7 +482,8 @@ Vue.component(
                             <h4>{{edge[0][0]}}[{{edge[0][1]}}] to {{edge[1][0]}}[{{edge[1][1]}}]</h4>
                         </div>
                         <label for="edge-name-input">Name</label>
-                        <input id="edge-name-input" type="text" v-model="edge[2]" placeholder="edge name" />
+                        <input id="edge-name-input" type="text" v-model="edge[2]" @keypress="stopPropagation" @keydown="stopPropagation"
+                            placeholder="edge name" />
                     </div>
                 </div>
             </section>
@@ -492,6 +496,11 @@ Vue.component(
     {
         props: {
             state: Object
+        },
+        methods: {
+            stopPropagation: function(event) {
+                event.stopPropagation();
+            }
         },
         computed: {
             node: function() {
@@ -506,7 +515,8 @@ Vue.component(
                         <h4>{{node.name}}[{{index}}]</h4>
                     </div>
                     <label for="axis-name-input">Name</label>
-                    <input id="axis-name-input" type="text" v-model="node.axes[index].name" placeholder="axis name" />
+                    <input id="axis-name-input" type="text" v-model="node.axes[index].name" @keypress="stopPropagation" @keydown="stopPropagation"
+                        placeholder="axis name" />
                 </div>
             </section>
         `
@@ -516,6 +526,7 @@ Vue.component(
 Vue.component(
     'toolbar-multinode-section',
     {
+        mixins: [mixinDelete],
         props: {
             state: Object
         },
@@ -534,6 +545,10 @@ Vue.component(
             this.spacingX = this.state.selectedNodes[1].position.x - this.state.selectedNodes[0].position.x;
         },
         methods: {
+            deleteNodes: function(event) {
+                event.preventDefault();
+                this.deleteSelectedNodes();
+            },
             alignVertically: function(event) {
                 event.preventDefault();
                 for (let i = 0; i < this.state.selectedNodes.length; i++) {
@@ -567,7 +582,10 @@ Vue.component(
         template: `
             <div>
                 <section>
-                    <h2>Multiple Nodes</h2>
+                    <div>
+                        <a class="delete" href="" @click="deleteNodes(event)">delete</a>
+                        <h2>Multiple Nodes</h2>
+                    </div>
                     <div v-for="node in state.selectedNodes">
                         <p><strong>{{node.name}}</strong> - <em>x</em>: {{node.position.x}}, <em>y</em>: {{node.position.y}}</p>
                     </div>

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -144,9 +144,11 @@ Vue.component(
             },
             hue: function() {
                 this.node.hue = parseFloat(this.hue);
+                this.editNode();
             },
             rotation: function() {
                 this.node.rotation = parseFloat(this.rotation);
+                this.editNode();
             }
         },
         methods: {
@@ -161,22 +163,29 @@ Vue.component(
                     axis.angle = allAxes[index].angle;
                     axis.position = allAxes[index].position;
                 });
+                this.editNode();
             },
             rotate: function(angle) {
                 this.rotation += angle;
             },
-            editNode: function(event) {
+            updateNode: function(event) {
                 event.preventDefault();
-                if (this.state.selectedNodes.length === 0) {
+                if (this.createMode) {
                     this.createNode();
                 }
-                if (this.state.selectedNodes.length === 1) {
-                    let oldNode = this.state.selectedNodes[0];
-                    let newNode = JSON.parse(JSON.stringify(this.node));
-                    newNode.position = oldNode.position;
-                    this.state.selectedNodes = [newNode];
-                    this.pushNode(newNode, oldNode.name);
+                else {
+                    this.editNode();
                 }
+            },
+            editNode: function(event) {
+                if (this.createMode) {
+                    return;
+                }
+                let oldNode = this.state.selectedNodes[0];
+                let newNode = JSON.parse(JSON.stringify(this.node));
+                newNode.position = oldNode.position;
+                this.state.selectedNodes = [newNode];
+                this.pushNode(newNode, oldNode.name);
             },
             createNode: function() {
                 let workspace = document.getElementById('workspace').getBoundingClientRect();
@@ -243,9 +252,11 @@ Vue.component(
                     }
                 }
                 this.node.axes.push(JSON.parse(JSON.stringify(candidateAxis)));
+                this.editNode();
             },
             onNodeAxisMouseDown: function(node, axis) {
                 this.node.axes.splice(axis, 1);
+                this.editNode();
             },
             axes: function(size1, size2) {
                 let makeAxis = function(direction, position) {
@@ -345,6 +356,7 @@ Vue.component(
                         }
                     }
                 }
+                this.editNode();
             }
         },
         computed: {
@@ -428,7 +440,7 @@ Vue.component(
                 </div>
                 <div class="button-holder">
                     <h4>Name</h4>
-                    <form @submit="editNode">
+                    <form @submit="updateNode">
                         <input type="text" v-model="node.name" placeholder="node name" />
                         <input type="text" v-if="renderLaTeX" v-model="node.displayName" placeholder="LaTeX label" />
                         <input type="submit" :value="createMode ? 'Create' : 'Edit'" :disabled="createNodeDisabled" />

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -43,7 +43,7 @@ Vue.component(
                 this.state.nodes = this.state.nodes.filter(function(node) {
                     return node.name !== selectedName;
                 });
-                this.selectedNodes = [];
+                this.state.selectedNodes = [];
             },
             copyNode: function(event) {
                 event.preventDefault();

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -28,23 +28,6 @@ Vue.component(
             deselectNode: function() {
                 this.state.selectedNodes = [];
             },
-            deleteNode: function(event) {
-                event.preventDefault();
-                let selectedName = this.state.selectedNodes[0].name;
-
-                this.state.edges = this.state.edges.filter(function(edge) {
-                    if (edge[0][0] === selectedName || edge[1][0] === selectedName) {
-                        return false;
-                    }
-                    else {
-                        return true;
-                    }
-                });
-                this.state.nodes = this.state.nodes.filter(function(node) {
-                    return node.name !== selectedName;
-                });
-                this.state.selectedNodes = [];
-            },
             copyNode: function(event) {
                 event.preventDefault();
                 let workspace = document.getElementById('workspace').getBoundingClientRect();
@@ -61,9 +44,6 @@ Vue.component(
                 this.state.selectedNodes = [node];
                 this.copyNodeName = '';
             },
-            rotate: function(angle) {
-                this.node.rotation += angle;
-            }
         },
         computed: {
             node: function() {
@@ -83,39 +63,28 @@ Vue.component(
         },
         template: `
             <div class="toolbar">
-                <div v-if="state.selectedNodes.length === 0">
-                    <tensor-creator :state="state" />
-                    <section>
+                <div v-if="state.selectedNodes.length < 2">
+                    <tensor-editor :state="state" />
+                    <section v-if="state.selectedNodes.length === 0">
                         <h3>Selecting nodes</h3>
                         <p>Click a node to select it for editing.</p>
                         <p>Drag-select or shift-click multiple nodes to drag as a group and adjust alignment and
                         spacing.</p>
                     </section>
-                </div>
-                <div v-else-if="state.selectedNodes.length === 1">
-                    <section>
+                    <section v-else>
                         <div class="button-holder">
                             <button @click="deselectNode">Create new node</button>
                         </div>
-                    </section>
-                    <section>
-                        <div>
-                            <a class="delete" href="" @click="deleteNode(event)">delete</a>
-                            <h2>Node: {{node.name}}</h2>
-                        </div>
-                        <h4>Set LaTeX Label</h4>
-                        <input type="text" v-model="node.displayName" placeholder="LaTeX label" />
                         <h4>Copy Node</h4>
                         <form @submit="copyNode">
                             <input type="text" v-model="copyNodeName" placeholder="name of copy" />
                             <input type="submit" value="Copy" :disabled="copyNodeDisabled" />
                         </form>
-                        <h4>Rotate</h4>
-                        <button @click="rotate(-Math.PI / 4)">Counterclockwise</button>
-                        <button @click="rotate(Math.PI / 4)">Clockwise</button>
                     </section>
-                    <toolbar-edge-section :state="state" />
-                    <toolbar-axis-section :state="state" />
+                    <div v-if="state.selectedNodes.length === 1">
+                        <toolbar-edge-section :state="state" />
+                        <toolbar-axis-section :state="state" />
+                    </div>
                 </div>
                 <div v-else>
                     <toolbar-multinode-section :state="state" />
@@ -126,7 +95,7 @@ Vue.component(
 );
 
 Vue.component(
-    'tensor-creator',
+    'tensor-editor',
     {
         mixins: [mixinGeometry],
         props: {
@@ -137,6 +106,7 @@ Vue.component(
                 size1: 1,
                 size2: 1,
                 hue: 0,
+                rotation: 0,
                 node: {},
                 width: 250,
                 height: 250,
@@ -153,34 +123,116 @@ Vue.component(
             this.reset();
         },
         watch: {
+            'state.selectedNodes': function() {
+                if (this.state.selectedNodes.length !== 1) {
+                    this.reset();
+                }
+                else {
+                    this.node = JSON.parse(JSON.stringify(this.state.selectedNodes[0]));
+                    this.node.position = JSON.parse(JSON.stringify(this.nodeInitial.position));
+                    this.size1 = this.node.size[0];
+                    this.size2 = this.node.size[1];
+                    this.hue = this.node.hue;
+                    this.rotation = this.node.rotation;
+                }
+            },
             size1: function() {
-                this.reset();
+                this.resize();
             },
             size2: function() {
-                this.reset();
+                this.resize();
             },
             hue: function() {
                 this.node.hue = parseFloat(this.hue);
+            },
+            rotation: function() {
+                this.node.rotation = parseFloat(this.rotation);
             }
         },
         methods: {
-            reset: function () {
+            reset: function() {
                 this.node = JSON.parse(JSON.stringify(this.nodeInitial));
             },
-            createNode: function (event) {
+            resize: function() {
+                this.node.size = [parseFloat(this.size1), parseFloat(this.size2)];
+                let allAxes = this.axes(parseFloat(this.size1), parseFloat(this.size2));
+                this.node.axes.splice(allAxes.length);
+                this.node.axes.forEach(function(axis, index) {
+                    axis.angle = allAxes[index].angle;
+                    axis.position = allAxes[index].position;
+                });
+            },
+            rotate: function(angle) {
+                this.rotation += angle;
+            },
+            editNode: function(event) {
                 event.preventDefault();
+                if (this.state.selectedNodes.length === 0) {
+                    this.createNode();
+                }
+                if (this.state.selectedNodes.length === 1) {
+                    let oldNode = this.state.selectedNodes[0];
+                    let newNode = JSON.parse(JSON.stringify(this.node));
+                    newNode.position = oldNode.position;
+                    this.state.selectedNodes = [newNode];
+                    this.pushNode(newNode, oldNode.name);
+                }
+            },
+            createNode: function() {
                 let workspace = document.getElementById('workspace').getBoundingClientRect();
 
-                this.node.position = {x: workspace.width / 2, y: workspace.height / 2};
+                let node = JSON.parse(JSON.stringify(this.node));
+                node.position = {x: workspace.width / 2, y: workspace.height / 2};
                 if (this.state.snapToGrid) {
-                    this.node.position.x = Math.round(this.node.position.x / this.gridSpacing) * this.gridSpacing;
-                    this.node.position.y = Math.round(this.node.position.y / this.gridSpacing) * this.gridSpacing;
+                    node.position.x = Math.round(this.node.position.x / this.gridSpacing) * this.gridSpacing;
+                    node.position.y = Math.round(this.node.position.y / this.gridSpacing) * this.gridSpacing;
                 }
-
-                this.state.nodes.push(this.node);
-                this.reset();
+                this.pushNode(node);
             },
-            onShadowAxisMouseDown: function (node, axis) {
+            deleteNode: function(event) {
+                event.preventDefault();
+                let selectedName = this.state.selectedNodes[0].name;
+
+                this.state.edges = this.state.edges.filter(function(edge) {
+                    return edge[0][0] !== selectedName && edge[1][0] !== selectedName
+                });
+                this.state.nodes = this.state.nodes.filter(function(node) {
+                    return node.name !== selectedName;
+                });
+                this.state.selectedNodes = [];
+            },
+            pushNode: function(node, originalName) {
+                // Eliminate edges that no longer connect to axes
+                this.state.edges = this.state.edges.filter(function(edge) {
+                    if (edge[0][0] === node.name || edge[0][0] === originalName) {
+                        return edge[0][1] < node.axes.length;
+                    }
+                    if (edge[1][0] === node.name || edge[1][0] === originalName) {
+                        return edge[1][1] < node.axes.length
+                    }
+                });
+                // Rename edges if there is a name change
+                if (originalName) {
+                    this.state.edges.forEach(function(edge) {
+                        if (edge[0][0] === originalName) {
+                            edge[0].splice(0, 1, node.name);
+                        }
+                        if (edge[1][0] === originalName) {
+                            edge[1].splice(0, 1, node.name);
+                        }
+                    });
+                }
+                // Actually insert the node object in state.nodes
+                for (let i = 0; i < this.state.nodes.length; i++) {
+                    if (this.state.nodes[i].name === originalName
+                        || this.state.nodes[i].name === node.name) {
+                        this.state.nodes.splice(i, 1, node);
+                        return;
+                    }
+                }
+                this.state.nodes.push(this.node);
+            },
+            onShadowAxisMouseDown: function(node, axis) {
                 let candidateAxis = this.nodeShadow.axes[axis];
                 for (let j = 0; j < this.node.axes.length; j++) {
                     let existingAxis = this.node.axes[j];
@@ -192,11 +244,11 @@ Vue.component(
                 }
                 this.node.axes.push(JSON.parse(JSON.stringify(candidateAxis)));
             },
-            onNodeAxisMouseDown: function (node, axis) {
+            onNodeAxisMouseDown: function(node, axis) {
                 this.node.axes.splice(axis, 1);
             },
-            axes: function (size1, size2) {
-                let makeAxis = function (direction, position) {
+            axes: function(size1, size2) {
+                let makeAxis = function(direction, position) {
                     return {name: null, angle: direction * Math.PI / 4, position: position};
                 };
                 let output = [];
@@ -241,11 +293,11 @@ Vue.component(
 
                 return output;
             },
-            onMouseDown: function (event) {
+            onMouseDown: function(event) {
                 document.addEventListener('mousemove', this.onMouseMove);
                 document.addEventListener('mouseup', this.onMouseUp);
 
-                let workspace = document.getElementById('tensor-creator-workspace').getBoundingClientRect();
+                let workspace = document.getElementById('tensor-editor-workspace').getBoundingClientRect();
 
                 this.dragSelector.dragging = true;
                 this.dragSelector.startX = event.clientX - workspace.left;
@@ -253,13 +305,13 @@ Vue.component(
                 this.dragSelector.endX = event.clientX - workspace.left;
                 this.dragSelector.endY = event.clientY - workspace.top;
             },
-            onMouseMove: function (event) {
-                let workspace = document.getElementById('tensor-creator-workspace').getBoundingClientRect();
+            onMouseMove: function(event) {
+                let workspace = document.getElementById('tensor-editor-workspace').getBoundingClientRect();
 
                 this.dragSelector.endX = event.clientX - workspace.left;
                 this.dragSelector.endY = event.clientY - workspace.top;
             },
-            onMouseUp: function () {
+            onMouseUp: function() {
                 document.removeEventListener('mousemove', this.onMouseMove);
                 document.removeEventListener('mouseup', this.onMouseUp);
 
@@ -296,12 +348,19 @@ Vue.component(
             }
         },
         computed: {
+            createMode: function() {
+                return this.state.selectedNodes.length === 0;
+            },
             createNodeDisabled: function() {
-                return this.nameTaken || this.node.name == null || this.node.name === '';
+                return this.node.name == null || this.node.name === '' || this.nameTaken;
             },
             nameTaken: function() {
                 for (let i = 0; i < this.state.nodes.length; i++) {
                     if (this.node.name === this.state.nodes[i].name) {
+                        if (this.state.selectedNodes.length === 1) {
+                            // If editing and not changing name, don't count as taken.
+                            return this.state.nodes[i] !== this.state.selectedNodes[0];
+                        }
                         return true;
                     }
                 }
@@ -313,7 +372,7 @@ Vue.component(
                     size: [parseFloat(this.size1), parseFloat(this.size2)],
                     axes: [],
                     position: {x: 125, y: 125},
-                    rotation: 0,
+                    rotation: parseFloat(this.rotation),
                     hue: parseFloat(this.hue)
                 };
             },
@@ -323,7 +382,7 @@ Vue.component(
                     size: [parseFloat(this.size1), parseFloat(this.size2)],
                     axes: this.axes(parseFloat(this.size1), parseFloat(this.size2)),
                     position: {x: 125, y: 125},
-                    rotation: 0,
+                    rotation: parseFloat(this.rotation),
                     hue: null
                 };
             },
@@ -333,11 +392,15 @@ Vue.component(
             }
         },
         template: `
-            <section class="tensor-creator">
-                <h2>Create New Node</h2>
-                <p>Click on an axis to add or remove it.</p>
+            <section class="tensor-editor">
+                <h2 v-if="createMode">Create New Node</h2>
+                <div v-else>
+                    <a class="delete" href="" @click="deleteNode(event)">delete</a>
+                    <h2>Edit Node {{state.selectedNodes[0].name}}</h2>
+                </div>
+                <p>Click on an axis to add or remove it. Drag-select to add multiple axes.</p>
                 <div class="svg-container">
-                    <svg class="workspace" id="tensor-creator-workspace" xmlns="http://www.w3.org/2000/svg" :width="width" :height="height"
+                    <svg class="workspace" id="tensor-editor-workspace" xmlns="http://www.w3.org/2000/svg" :width="width" :height="height"
                         @mousedown="onMouseDown">
                         <node :node="nodeShadow" :state="state" :disableDragging="true" :shadow="true"
                             @axismousedown="onShadowAxisMouseDown(node, ...arguments)" />
@@ -358,11 +421,17 @@ Vue.component(
                     <label>Color</label>
                     <input type="range" v-model="hue" min="0" max="359" step="1" class="slider">
                 </div>
+                <div>
+                    <h4>Rotate</h4>
+                    <button @click="rotate(-Math.PI / 4)">Counterclockwise</button>
+                    <button @click="rotate(Math.PI / 4)">Clockwise</button>
+                </div>
                 <div class="button-holder">
-                    <form @submit="createNode">
+                    <h4>Name</h4>
+                    <form @submit="editNode">
                         <input type="text" v-model="node.name" placeholder="node name" />
                         <input type="text" v-if="renderLaTeX" v-model="node.displayName" placeholder="LaTeX label" />
-                        <input type="submit" value="Create" :disabled="createNodeDisabled" />
+                        <input type="submit" :value="createMode ? 'Create' : 'Edit'" :disabled="createNodeDisabled" />
                     </form>
                 </div>
             </section>

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -144,7 +144,6 @@ Vue.component(
             },
             hue: function() {
                 this.node.hue = parseFloat(this.hue);
-                this.editNode();
             },
             rotation: function() {
                 this.node.rotation = parseFloat(this.rotation);
@@ -163,7 +162,6 @@ Vue.component(
                     axis.angle = allAxes[index].angle;
                     axis.position = allAxes[index].position;
                 });
-                this.editNode();
             },
             rotate: function(angle) {
                 this.rotation += angle;
@@ -423,15 +421,15 @@ Vue.component(
                     </svg>
                 </div>
                     <label>Width {{size1}}</label>
-                    <input type="range" v-model="size1" min="1" max="7" step="1" class="slider">
+                    <input type="range" v-model="size1" min="1" max="7" step="1" class="slider" @mouseup="editNode">
                 </div>
                 </div>
                     <label>Height {{size2}}</label>
-                    <input type="range" v-model="size2" min="1" max="7" step="1" class="slider">
+                    <input type="range" v-model="size2" min="1" max="7" step="1" class="slider" @mouseup="editNode">
                 </div>
                 <div>
                     <label>Color</label>
-                    <input type="range" v-model="hue" min="0" max="359" step="1" class="slider">
+                    <input type="range" v-model="hue" min="0" max="359" step="1" class="slider" @mouseup="editNode">
                 </div>
                 <div>
                     <h4>Rotate</h4>

--- a/js/workspace.js
+++ b/js/workspace.js
@@ -34,7 +34,6 @@ Vue.component(
                     y: null,
                     node: null,
                     axis: null,
-                    dragging: false
                 }
 			};
 		},
@@ -104,19 +103,19 @@ Vue.component(
             },
             dragAxis: function(event) {
                 let workspace = document.getElementById('workspace').getBoundingClientRect();
-                this.protoEdge.dragging = true;
+                this.state.draggingProtoEdge = true;
                 this.protoEdge.x = event.clientX - workspace.left;
                 this.protoEdge.y = event.clientY - workspace.top;
             },
             releaseAxisDrag: function() {
                 document.removeEventListener('mousemove', this.dragAxis);
                 document.removeEventListener('mouseup', this.releaseAxisDrag);
-                this.protoEdge.dragging = false;
+                this.state.draggingProtoEdge = false;
                 this.protoEdge.node = null;
                 this.protoEdge.axis = null;
             },
             onAxisMouseUp: function(node, axis) {
-		        if (this.protoEdge.dragging) {
+		        if (this.state.draggingProtoEdge) {
                     if (this.axisOccupied(node, axis)) {
                         return;
                     }
@@ -146,7 +145,7 @@ Vue.component(
 			<svg class="workspace" id="workspace" xmlns="http://www.w3.org/2000/svg"
 			    :width="width" :height="height" @mousedown="onMouseDown">
                 <text id="saved-state" display="none"></text>
-                <proto-edge v-if="protoEdge.dragging" :x="protoEdge.x" :y="protoEdge.y"
+                <proto-edge v-if="state.draggingProtoEdge" :x="protoEdge.x" :y="protoEdge.y"
 				    :node="protoEdge.node" :axis="protoEdge.axis" />
 				<edge v-for="edge in state.edges" :edge="edge" :state="state" /> 
 				<node v-for="node in state.nodes" :node="node" :state="state"

--- a/js/workspace.js
+++ b/js/workspace.js
@@ -40,7 +40,9 @@ Vue.component(
 		},
         methods: {
             onMouseDown: function(event) {
-                this.state.selectedNodes = [];
+                if (this.state.selectedNodes.length > 0) {
+                    this.state.selectedNodes = [];
+                }
 
                 document.addEventListener('mousemove', this.onMouseMove);
                 document.addEventListener('mouseup', this.onMouseUp);
@@ -70,7 +72,9 @@ Vue.component(
                 let y1 = this.dragSelector.startY;
                 let y2 = this.dragSelector.endY;
 
-                this.state.selectedNodes = [];
+                if (this.state.selectedNodes.length > 0) {
+                    this.state.selectedNodes = [];
+                }
                 let selected = this.state.selectedNodes;
                 this.state.nodes.forEach(function(node) {
                     let x = node.position.x;
@@ -81,11 +85,13 @@ Vue.component(
                         }
                     }
                 });
-                this.state.selectedNodes.sort(function(node1, node2) {
-                    let distance1 = (node1.position.x - x1) ** 2 + (node1.position.y - y1) ** 2;
-                    let distance2 = (node2.position.x - x1) ** 2 + (node2.position.y - y1) ** 2;
-                    return distance1 - distance2;
-                })
+                if (selected.length > 0) {
+                    selected.sort(function (node1, node2) {
+                        let distance1 = (node1.position.x - x1) ** 2 + (node1.position.y - y1) ** 2;
+                        let distance2 = (node2.position.x - x1) ** 2 + (node2.position.y - y1) ** 2;
+                        return distance1 - distance2;
+                    })
+                }
             },
             onAxisMouseDown: function(node, axis) {
                 if (this.axisOccupied(node, axis)) {

--- a/js/workspace.js
+++ b/js/workspace.js
@@ -139,6 +139,7 @@ Vue.component(
 		template: `
 			<svg class="workspace" id="workspace" xmlns="http://www.w3.org/2000/svg"
 			    :width="width" :height="height" @mousedown="onMouseDown">
+                <text id="saved-state" display="none"></text>
                 <proto-edge v-if="protoEdge.dragging" :x="protoEdge.x" :y="protoEdge.y"
 				    :node="protoEdge.node" :axis="protoEdge.axis" />
 				<edge v-for="edge in state.edges" :edge="edge" :state="state" /> 


### PR DESCRIPTION
- Add ability to save/load workspace state to/from SVG export
- Only show example nodes for first-time users
- Fix bug where a deleted node will remain selected
- Tensor creator renamed to tensor editor, can now edit existing nodes
- Editing now reflected in real-time on main workspace
- Reduce number of state changes and saves
- Add undo, redo buttons
- Click on edge or edge label to delete
- Add hotkeys
- Add Help window
- Add "Copy to clipboard" button and copy animation
- Add 'C' hotkey to copy code output to clipboard
- Changed most hotkeys to require Ctrl or Cmd modifier keys
- Add Cmd/Ctrl-H hotkey show the help window
- Fix bug where creating a new node deletes all edges
- Highlight edge when moused over to indicate clickable